### PR TITLE
fix: remove deprecated eslint plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   root: true,
-  extends: ["standard-with-typescript", "plugin:prettier/recommended", "plugin:@typescript-eslint/recommended"],
+  extends: ["love", "plugin:prettier/recommended", "plugin:@typescript-eslint/recommended"],
   rules: {
     "@typescript-eslint/no-floating-promises": ["off"],
     "prefer-const": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "peerDependencies": {
         "eslint": "^8.57.0",
+        "eslint-config-love": "^43.1.0",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-config-standard-with-typescript": "^43.0.1",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-promise": "^6.1.1",
@@ -1125,6 +1125,24 @@
         "eslint": ">=6.0.0"
       }
     },
+    "node_modules/eslint-config-love": {
+      "version": "43.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-love/-/eslint-config-love-43.1.0.tgz",
+      "integrity": "sha512-r3+7mSaOl0BEGf8LEntPPDbWTDw8o0Dpy9vdts7m+NAuSpmz9C/gL+64lC0Z8nKNE4uwdymPGll4czGQiR+XmQ==",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/parser": "^6.4.0",
+        "eslint-config-standard": "17.1.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^6.4.0",
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
+        "eslint-plugin-promise": "^6.0.0",
+        "typescript": "*"
+      }
+    },
     "node_modules/eslint-config-prettier": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
@@ -1164,25 +1182,6 @@
         "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
         "eslint-plugin-promise": "^6.0.0"
-      }
-    },
-    "node_modules/eslint-config-standard-with-typescript": {
-      "version": "43.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-43.0.1.tgz",
-      "integrity": "sha512-WfZ986+qzIzX6dcr4yGUyVb/l9N3Z8wPXCc5z/70fljs3UbWhhV+WxrfgsqMToRzuuyX9MqZ974pq2UPhDTOcA==",
-      "deprecated": "Please use eslint-config-love, instead.",
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/parser": "^6.4.0",
-        "eslint-config-standard": "17.1.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^6.4.0",
-        "eslint": "^8.0.1",
-        "eslint-plugin-import": "^2.25.2",
-        "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
-        "eslint-plugin-promise": "^6.0.0",
-        "typescript": "*"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
   "author": "aimee rivers",
   "license": "ISC",
   "peerDependencies": {
-    "eslint": "^8.57.0",
+    "eslint-config-love": "^43.1.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-config-standard-with-typescript": "^43.0.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-simple-import-sort": "^12.0.0",
     "eslint-plugin-unused-imports": "^3.1.0",
+    "eslint": "^8.57.0",
     "prettier": "^3.2.5"
   }
 }


### PR DESCRIPTION
it is now recommended to use eslint-config-love instead of eslint-config-standard-with-typescript